### PR TITLE
Disable tooltip for own user name

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-router-dom": "^4.1.2",
     "react-swipe": "^5.1.0",
     "react-toastify": "^3.3.4",
-    "react-tooltip": "^3.3.1",
+    "react-tooltip": "^3.4.0",
     "react-transition-group": "1.x",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.1",

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -80,7 +80,14 @@ export class UserList extends React.Component<UserListProps, UserListState> {
           data-for={'ALL' + user.id}
           {...isCurrentUser && { onClick: onToggleReadyState }}
         />
-        <ReactTooltip id={'ALL' + user.id} place="bottom" effect="solid" />
+        {!isCurrentUser && (
+          <ReactTooltip
+            id={'ALL' + user.id}
+            place="bottom"
+            effect="solid"
+            isCapture={true}
+          />
+        )}
         <img
           className="board__user-image"
           src={

--- a/yarn.lock
+++ b/yarn.lock
@@ -6056,7 +6056,7 @@ react-toastify@^3.3.4:
     prop-types "^15.6.0"
     react-transition-group "^2.2.1"
 
-react-tooltip@^3.3.1:
+react-tooltip@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.4.0.tgz#037f38f797c3e6b1b58d2534ccc8c2c76af4f52d"
   dependencies:


### PR DESCRIPTION
Fixes #43 

* First tap is opening the tooltip containing the own user name
* Second tap is the "ready" click

Disabling the tooltip will fix this issue